### PR TITLE
escape markdown for usernames in response content

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from urllib.parse import urljoin
 
 import requests
 import telebot
+import telebot.formatting
 from dotenv import load_dotenv
 from google.generativeai.types import HarmCategory, HarmBlockThreshold
 from langchain.chains.combine_documents.stuff import StuffDocumentsChain
@@ -373,6 +374,9 @@ def reply_to_telegram_message(message, response_content):
     """
     chat_id = message.chat.id
     try:
+        usernames = re.findall(r"(?<!\S)@[a-zA-Z0-9._-]+", response_content)
+        for username in usernames:
+            response_content = response_content.replace(username, telebot.formatting.escape_markdown(username))
         bot.reply_to(message, response_content, parse_mode='markdown')
         logging.debug(f"Sent response for chat {chat_id}")
     except Exception as e:


### PR DESCRIPTION
This pull request includes changes to improve the handling of Telegram messages by escaping markdown characters in usernames and importing necessary modules. 

This change ensure `@user_ids_like_this_one` get outputted correctly instead of `@useridslikethisone` where underscores are treated as _italic_ markdown formatting 

Improvements to Telegram message handling:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R13): Added `telebot.formatting` import to support markdown formatting.
* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R377-R379): Modified `reply_to_telegram_message` function to escape markdown characters in usernames found in the response content using `telebot.formatting.escape_markdown`.