### PR TITLE
#28 Use user's first name when username is not available

### DIFF
--- a/main.py
+++ b/main.py
@@ -223,7 +223,12 @@ def process_message_buffer(bot: TeleBot):
                 logging.debug(f"Message text: {message_text}")
 
                 # build message for llm context
-                message_parts = f"@{get_message_from(message)}: "
+                username = get_message_from(message)
+                if username:
+                    message_parts = f"@{username}: "
+                else:
+                    user_name = message.from_user.first_name or "Unknown user"
+                    message_parts = f"{user_name}: "
                 if is_bot_reply(config.bot_username, message):
                     message_parts += f"@{config.bot_username} "
                 elif is_reply(message):


### PR DESCRIPTION
This PR updates the bot to use the user's first name when the username is not available.

#28 