### PR TITLE
Fix: Explicitly define ReadDocumentTool schema to avoid Gemini API errors

### DIFF
--- a/manolo_bot/ai/tools.py
+++ b/manolo_bot/ai/tools.py
@@ -11,7 +11,7 @@ from langchain_community.document_loaders import WebBaseLoader
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool, tool
 from langchain_tavily import TavilySearch
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from youtube_transcript_api import TranscriptsDisabled, YouTubeTranscriptApi
 
 from manolo_bot.ai.config import BotConfig
@@ -208,6 +208,10 @@ def get_search_instructions() -> str:
     """
 
 
+class ReadDocumentInput(BaseModel):
+    filename: str = Field(description="The name of the document file to read")
+
+
 class ReadDocumentTool(BaseTool):
     """
     Tool for reading the content of a document that the user has uploaded.
@@ -219,6 +223,7 @@ class ReadDocumentTool(BaseTool):
         "Tool for reading the content of a document that the user has uploaded. "
         "Input should be the filename provided in the pointer message."
     )
+    args_schema: type[BaseModel] = ReadDocumentInput
     document_storage: BaseDocumentStorage
     context_max_tokens: int = 4096
 


### PR DESCRIPTION
#### Summary
This Pull Request fixes a `400 INVALID_ARGUMENT` error encountered when using Google Gemini models (e.g., `gemini-flash-latest`) with the `read_document` tool. The issue was caused by the automatic inclusion of internal configuration objects in the tool's JSON schema, which violated Gemini's strict API validation rules.

#### Root Cause
By default, LangChain's automatic schema generation includes all arguments from the tool's `_arun` method in the JSON schema sent to the LLM. In `ReadDocumentTool`, the `config: RunnableConfig` argument was being serialized into the schema. 

The `callbacks` property within `RunnableConfig` generated a schema that lacked the required `items` field for an array type, which the Gemini API rejected with the following error:
`* GenerateContentRequest.tools[0].function_declarations[7].parameters.properties[config].properties[callbacks].items: missing field.`

#### Changes
- **Defined `ReadDocumentInput`**: Created a Pydantic model that explicitly defines only the `filename` parameter as the tool's input.
- **Configured `args_schema`**: Set the `args_schema` property of `ReadDocumentTool` to `ReadDocumentInput`.
- **Cleaned API Schema**: This ensures that only the `filename` field is exposed to the LLM in the tool definition, effectively hiding the `RunnableConfig` from the API request while keeping it available for internal runtime use.

#### Verification Results
- **Schema Validation**: Verified that the generated JSON schema for the tool now only contains the `filename` property.
- **Functionality**: Confirmed that `RunnableConfig` is still correctly passed to the `_arun` method by LangChain at runtime, allowing the tool to retrieve the `chat_id` and access the correct document storage.

#### Related Issues
Closes #60