### PR TITLE
Add MAX_VOICE_SIZE_BYTES to limit voice message file size

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,10 @@ The document text is stored separately from chat history to keep memory clean.
 `ENABLE_GROUP_ASSISTANT`: Enable group assistant for group chats (True, False). The bot will respond to group chats with
 a question mark. The default value is False.
 
-#### Document processing configuration
+#### File size limits and document storage
 
 `MAX_DOCUMENT_SIZE_BYTES`: Maximum size of documents the bot will process (default: 2MB).
+`MAX_VOICE_SIZE_BYTES`: Maximum size of voice messages the bot will process (default: 2MB).
 `DOCUMENT_STORAGE_PATH`: Directory where extracted document text is stored. Defaults to a system temporary directory.
 
 #### Enable rate limiting

--- a/docs/source/usage_app.rst
+++ b/docs/source/usage_app.rst
@@ -146,12 +146,15 @@ Image and Voice
 * `WEBUI_SD_API_PARAMS`: A JSON string of parameters for the Stable Diffusion API (e.g., `{"steps": 20, "width": 512}`).
 * `WEBUI_SD_API_NEGATIVE_PROMPT`: Words or concepts you want Stable Diffusion to avoid.
 
-Document Processing
-~~~~~~~~~~~~~~~~~~~
+Document and Voice Processing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When `DOCUMENT_MULTIMODAL` is enabled, the bot can process uploaded files. It extracts the text content, cleans it, and stores it in a temporary storage so the LLM can reference it during the conversation.
 
+Similarly, when `AUDIO_MULTIMODAL` is enabled, the bot can process voice messages, but only up to the configured maximum size.
+
 * `MAX_DOCUMENT_SIZE_BYTES`: Maximum size of documents the bot will process (default: `2097152` bytes / 2MB).
+* `MAX_VOICE_SIZE_BYTES`: Maximum size of voice messages the bot will process (default: `2097152` bytes / 2MB).
 * `DOCUMENT_STORAGE_PATH`: Directory where extracted document text is stored. Defaults to a system temporary directory (`/tmp/manolo_bot/documents` on Linux).
 
 Storage and Persistence

--- a/docs/source/usage_app.rst
+++ b/docs/source/usage_app.rst
@@ -147,7 +147,7 @@ Image and Voice
 * `WEBUI_SD_API_NEGATIVE_PROMPT`: Words or concepts you want Stable Diffusion to avoid.
 
 Document and Voice Processing
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When `DOCUMENT_MULTIMODAL` is enabled, the bot can process uploaded files. It extracts the text content, cleans it, and stores it in a temporary storage so the LLM can reference it during the conversation.
 

--- a/env.example
+++ b/env.example
@@ -62,8 +62,9 @@ TELEGRAM_BOT_USERNAME=Your telegram bot username
 # Advanced Settings
 # LOGGING_LEVEL=INFO
 # CONTEXT_MAX_TOKENS=4096
-# Document processing configuration
+# File size limits and document storage
 # MAX_DOCUMENT_SIZE_BYTES=2097152
+# MAX_VOICE_SIZE_BYTES=2097152
 # DOCUMENT_STORAGE_PATH=/tmp/manolo_bot/documents
 
 # RATE_LIMITER_REQUESTS_PER_SECOND=0.25

--- a/manolo_bot/ai/config.py
+++ b/manolo_bot/ai/config.py
@@ -37,6 +37,7 @@ class BotConfig:
     # Web content retrieval configuration
     web_content_request_timeout: int = 10
     max_document_size: int = 2 * 1024 * 1024
+    max_voice_size: int = 2 * 1024 * 1024
 
     can_use_tavily_search: bool = False
 

--- a/manolo_bot/ai/llmagent.py
+++ b/manolo_bot/ai/llmagent.py
@@ -148,12 +148,8 @@ class LLMAgent(LLMBot):
 
         try:
             async with aiohttp.ClientSession() as session:
-                timeout = self._get_session_timeout()
-
-                async with session.get(audio, timeout=timeout) as response:
-                    response.raise_for_status()
-                    audio_bytes = await response.read()
-                    audio_data = base64.b64encode(audio_bytes).decode("utf-8")
+                audio_bytes = await self._download_file(audio, session, size_limit=self.bot_config.max_voice_size)
+                audio_data = base64.b64encode(audio_bytes).decode("utf-8")
 
                 llm_message = HumanMessage(
                     content=[
@@ -176,6 +172,14 @@ class LLMAgent(LLMBot):
                         {"messages": self.system_instructions + self.messages_storage.messages}, config=config
                     )
                 )["messages"][-1]
+        except FileTooLargeError:
+            error_prompt = (
+                f"Generate a brief, friendly response in {self.bot_config.preferred_language} "
+                f"explaining that the voice message is too long and you cannot process it. "
+                f"Keep it under 150 characters and maintain your character's style."
+            )
+            feedback = await self.generate_feedback_message(error_prompt, chat_id=chat_id)
+            response = AIMessage(content=feedback)
         except (aiohttp.ClientError, Exception) as e:
             if isinstance(e, aiohttp.ClientError):
                 logging.error(f"Failed to get audio: {audio}")

--- a/manolo_bot/ai/llmbot.py
+++ b/manolo_bot/ai/llmbot.py
@@ -387,7 +387,7 @@ class LLMBot:
 
         try:
             async with aiohttp.ClientSession() as session:
-                audio_bytes = await self._download_file(audio, session)
+                audio_bytes = await self._download_file(audio, session, size_limit=self.bot_config.max_voice_size)
                 audio_data = base64.b64encode(audio_bytes).decode("utf-8")
 
                 llm_message = HumanMessage(
@@ -399,9 +399,7 @@ class LLMBot:
                         {
                             "type": "media",
                             "mime_type": "audio/ogg",
-                            # "data": audio_bytes,
                             "data": audio_data,
-                            # "file_uri": audio,
                         },
                     ]
                 )
@@ -411,6 +409,14 @@ class LLMBot:
                     self.system_instructions + self.messages_storage.messages,
                     config=self._get_langchain_config(chat_id),
                 )
+        except FileTooLargeError:
+            error_prompt = (
+                f"Generate a brief, friendly response in {self.bot_config.preferred_language} "
+                f"explaining that the voice message is too long and you cannot process it. "
+                f"Keep it under 150 characters and maintain your character's style."
+            )
+            feedback = await self.generate_feedback_message(error_prompt, chat_id=chat_id)
+            response = AIMessage(content=feedback)
         except (aiohttp.ClientError, Exception) as e:
             if isinstance(e, aiohttp.ClientError):
                 logging.error(f"Failed to get audio: {audio}")

--- a/manolo_bot/config.py
+++ b/manolo_bot/config.py
@@ -75,8 +75,11 @@ class Config(EnvModel):
         warning="MCP_SERVERS_CONFIG not set. MCP will be disabled.",
     )
 
-    # Document processing configuration
+    # File size limits
     max_document_size = IntegerField("MAX_DOCUMENT_SIZE_BYTES", default=2 * 1024 * 1024)  # 2MB
+    max_voice_size = IntegerField("MAX_VOICE_SIZE_BYTES", default=2 * 1024 * 1024)  # 2MB
+
+    # Document storage
     document_storage_path = StringField(
         "DOCUMENT_STORAGE_PATH", default=os.path.join(tempfile.gettempdir(), "manolo_bot", "documents")
     )

--- a/manolo_bot/main.py
+++ b/manolo_bot/main.py
@@ -170,6 +170,7 @@ bot_config = BotConfig(
     sdapi_params=config.sdapi_params,
     sdapi_negative_prompt=config.sdapi_negative_prompt,
     max_document_size=config.max_document_size,
+    max_voice_size=config.max_voice_size,
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manolo-bot"
-version = "0.2.2"
+version = "0.3.0"
 description = "AI-powered Telegram Chat Bot and Library using LLMs"
 authors = [{ name = "Carlos Cesar Caballero Díaz", email = "ccesarcaball.cc@gmail.com" }]
 readme = "README.md"

--- a/tests/ai_tests/test_llmagent.py
+++ b/tests/ai_tests/test_llmagent.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from langchain_core.messages import AIMessage, SystemMessage
 
 from manolo_bot.ai.llmagent import LLMAgent
+from manolo_bot.ai.llmbot import FileTooLargeError
 from manolo_bot.config import Config
 
 
@@ -29,6 +30,7 @@ class TestLlmAgent(unittest.IsolatedAsyncioTestCase):
         mock_config.use_tools = True
         mock_config.can_use_tavily_search = False
         mock_config.max_document_size = 10 * 1024 * 1024
+        mock_config.max_voice_size = 10 * 1024 * 1024
         mock_messages_storage = MagicMock()
         system_instructions = [SystemMessage(content="You are a helpful assistant")]
         agent = LLMAgent(mock_llm, mock_config, system_instructions, mock_messages_storage)
@@ -48,6 +50,7 @@ class TestLlmAgent(unittest.IsolatedAsyncioTestCase):
         mock_config.mcp_servers_config = {}
         mock_config.can_use_tavily_search = False
         mock_config.max_document_size = 10 * 1024 * 1024
+        mock_config.max_voice_size = 10 * 1024 * 1024
         mock_messages_storage = MagicMock()
 
         mock_tools = ["tool1", "tool2"]
@@ -180,16 +183,7 @@ class TestLlmAgent(unittest.IsolatedAsyncioTestCase):
         chat_id = 1
         text = "What did I say?"
         audio_url = "https://example.com/audio.ogg"
-
-        # Mock aiohttp session and response
-        mock_session = unittest.mock.MagicMock()
-        mock_response = unittest.mock.AsyncMock()
-        mock_response.read.return_value = b"fake_audio_data"
-        mock_response.status = 200
-        mock_response.raise_for_status = unittest.mock.MagicMock()
-
-        mock_session.get.return_value.__aenter__.return_value = mock_response
-        mock_session.__aenter__.return_value = mock_session
+        fake_audio_data = b"fake_audio_data"
 
         # Mock agent response
         mock_ai_message = AIMessage(content="You said 'Hello'.")
@@ -197,13 +191,29 @@ class TestLlmAgent(unittest.IsolatedAsyncioTestCase):
         mock_agent.ainvoke = unittest.mock.AsyncMock(return_value={"messages": [mock_ai_message]})
         agent.agent = mock_agent
 
-        with unittest.mock.patch("aiohttp.ClientSession", return_value=mock_session):
+        with patch("manolo_bot.ai.llmbot.LLMBot._download_file", return_value=fake_audio_data):
             # Act
             response = await agent.answer_voice_message(chat_id, text, audio_url)
 
             # Assert
             self.assertEqual(response.content, "You said 'Hello'.")
             mock_agent.ainvoke.assert_called_once()
+
+    async def test_answer_voice_message__too_large(self):
+        # Arrange
+        agent = self.get_basic_llm_agent()
+        agent.generate_feedback_message = AsyncMock(return_value="Voice message too long")
+        agent.bot_config.max_voice_size = 100  # Small limit
+
+        with patch(
+            "manolo_bot.ai.llmbot.LLMBot._download_file",
+            side_effect=FileTooLargeError("Voice message is too large (200 bytes)"),
+        ):
+            # Act
+            response = await agent.answer_voice_message(1, "prompt", "http://example.com/audio.ogg")
+
+            # Assert
+            self.assertEqual(response.content, "Voice message too long")
 
     def test_system_instructions_mapping(self):
         # Arrange

--- a/tests/ai_tests/test_llmbot.py
+++ b/tests/ai_tests/test_llmbot.py
@@ -248,7 +248,6 @@ class TestLlmBot(unittest.IsolatedAsyncioTestCase):
                 content=[
                     {"type": "text", "text": "Test"},
                     {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}},
-                    {"type": "media", "mime_type": "audio/ogg", "data": "a" * 120},
                 ]
             ),
         ]
@@ -260,30 +259,8 @@ class TestLlmBot(unittest.IsolatedAsyncioTestCase):
         result = llm_bot.count_tokens(messages)
 
         # Assert
-        self.assertEqual(result, 258 + 30 + 3)  # image (258) + media (120//4=30) + text (3)
+        self.assertEqual(result, 258 + 3)  # image (258) + text (3)
         mock_llm.get_num_tokens.assert_called_once_with("\n Hello\n Test")
-
-    def test_count_tokens__with_media_content(self):
-        # Arrange
-        llm_bot = self.get_basic_llm_bot()
-        messages = [
-            HumanMessage(
-                content=[
-                    {"type": "text", "text": "Check this audio"},
-                    {"type": "media", "mime_type": "audio/ogg", "data": "x" * 400},
-                ]
-            ),
-        ]
-        mock_llm = unittest.mock.MagicMock()
-        llm_bot.llm = mock_llm
-        mock_llm.get_num_tokens.return_value = 5
-
-        # Act
-        result = llm_bot.count_tokens(messages)
-
-        # Assert
-        self.assertEqual(result, 5 + 100)  # text (5) + media (400//4=100)
-        mock_llm.get_num_tokens.assert_called_once_with("\n Check this audio")
 
     async def test_generate_feedback_message__success_message(self):
         # Arrange

--- a/tests/ai_tests/test_llmbot.py
+++ b/tests/ai_tests/test_llmbot.py
@@ -30,6 +30,7 @@ class TestLlmBot(unittest.IsolatedAsyncioTestCase):
         mock_config.use_tools = False
         mock_config.can_use_tavily_search = False
         mock_config.max_document_size = 10 * 1024 * 1024
+        mock_config.max_voice_size = 10 * 1024 * 1024
         mock_messages_storage = MagicMock()
         mock_messages_storage.messages = []
 
@@ -247,6 +248,7 @@ class TestLlmBot(unittest.IsolatedAsyncioTestCase):
                 content=[
                     {"type": "text", "text": "Test"},
                     {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}},
+                    {"type": "media", "mime_type": "audio/ogg", "data": "a" * 120},
                 ]
             ),
         ]
@@ -258,8 +260,30 @@ class TestLlmBot(unittest.IsolatedAsyncioTestCase):
         result = llm_bot.count_tokens(messages)
 
         # Assert
-        self.assertEqual(result, 258 + 3)
+        self.assertEqual(result, 258 + 30 + 3)  # image (258) + media (120//4=30) + text (3)
         mock_llm.get_num_tokens.assert_called_once_with("\n Hello\n Test")
+
+    def test_count_tokens__with_media_content(self):
+        # Arrange
+        llm_bot = self.get_basic_llm_bot()
+        messages = [
+            HumanMessage(
+                content=[
+                    {"type": "text", "text": "Check this audio"},
+                    {"type": "media", "mime_type": "audio/ogg", "data": "x" * 400},
+                ]
+            ),
+        ]
+        mock_llm = unittest.mock.MagicMock()
+        llm_bot.llm = mock_llm
+        mock_llm.get_num_tokens.return_value = 5
+
+        # Act
+        result = llm_bot.count_tokens(messages)
+
+        # Assert
+        self.assertEqual(result, 5 + 100)  # text (5) + media (400//4=100)
+        mock_llm.get_num_tokens.assert_called_once_with("\n Check this audio")
 
     async def test_generate_feedback_message__success_message(self):
         # Arrange
@@ -365,6 +389,22 @@ class TestLlmBot(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.content, "NO_ANSWER")
         # Ensure no message was added to storage
         self.assertEqual(len(llm_bot.messages_storage.add_message.call_args_list), 0)
+
+    async def test_answer_voice_message__too_large(self):
+        # Arrange
+        llm_bot = self.get_basic_llm_bot()
+        llm_bot.generate_feedback_message = AsyncMock(return_value="Voice message too long")
+        llm_bot.bot_config.max_voice_size = 100  # Small limit
+
+        with patch(
+            "manolo_bot.ai.llmbot.LLMBot._download_file",
+            side_effect=FileTooLargeError("Voice message is too large (200 bytes)"),
+        ):
+            # Act
+            response = await llm_bot.answer_voice_message(1, "prompt", "http://example.com/audio.ogg")
+
+            # Assert
+            self.assertEqual(response.content, "Voice message too long")
 
     def test_system_instructions_mapping(self):
         # Arrange

--- a/uv.lock
+++ b/uv.lock
@@ -1571,7 +1571,7 @@ wheels = [
 
 [[package]]
 name = "manolo-bot"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiogram" },


### PR DESCRIPTION
Implements voice message size enforcement using the same `_download_file` pipeline used for documents, preventing users from flooding the context with arbitrarily large audio files.

- **New env var** `MAX_VOICE_SIZE_BYTES` (default 2MB) — separate from `MAX_DOCUMENT_SIZE_BYTES` so each can be tuned independently
- **`LLMBot.answer_voice_message`** now passes `size_limit=self.bot_config.max_voice_size` to `_download_file`, with `FileTooLargeError` caught and a friendly LLM-generated error message returned
- **`LLMAgent.answer_voice_message`** refactored from raw `response.read()` to use `_download_file`, fixing a pre-existing issue where it bypassed all size/timeout checks
- **`count_tokens`** now accounts for `"media"` items (voice messages in context) — estimated as `len(data) // 4` chars per token — so audio messages in history no longer silently bypass context truncation
- Updated `config.py`, `BotConfig`, `README.md`, `docs/source/usage_app.rst`, `env.example`
- Added tests: `test_answer_voice_message__too_large` in both `test_llmbot.py` and `test_llmagent.py`, plus `test_count_tokens__with_media_content`

 Closes #62