### PR TITLE
fix: account for audio messages in token counting for context truncation

### DIFF
--- a/manolo_bot/ai/llmbot.py
+++ b/manolo_bot/ai/llmbot.py
@@ -709,6 +709,18 @@ class LLMBot:
                     elif item.get("type") == "image_url":
                         # TODO: Use an LLM-based method to get the image token count.
                         extra_tokens += 258  # using gemini image context size
+                    elif item.get("type") == "media" and "audio" in item.get("mime_type", ""):
+                        # TODO: Use an LLM-based method to get the audio token count.
+                        # Estimate audio duration from raw binary size (assuming typical OGG voice at ~16kbps)
+                        # Then compute duration * 32 (Gemini tokenization rate for audio)
+                        audio_data = item.get("data", "")
+                        if audio_data:
+                            try:
+                                binary_size = len(base64.b64decode(audio_data))
+                                duration = binary_size / 2000  # 16kbps = 2000 bytes/s
+                                extra_tokens += int(duration * 32)
+                            except Exception as e:
+                                logging.error(f"Error estimating audio tokens: {e}")
             else:
                 context_text += "\n " + message.content
 

--- a/tests/ai_tests/test_llmbot.py
+++ b/tests/ai_tests/test_llmbot.py
@@ -262,6 +262,34 @@ class TestLlmBot(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, 258 + 3)  # image (258) + text (3)
         mock_llm.get_num_tokens.assert_called_once_with("\n Hello\n Test")
 
+    def test_count_tokens__with_audio_media(self):
+        # Arrange
+        llm_bot = self.get_basic_llm_bot()
+        # 16000 bytes of audio data.
+        # At 16kbps (2000 bytes/s), this is 8 seconds.
+        # 8 seconds * 32 tokens/s = 256 tokens.
+        audio_data = b"a" * 16000
+        encoded_audio = base64.b64encode(audio_data).decode("utf-8")
+
+        messages = [
+            HumanMessage(
+                content=[
+                    {"type": "text", "text": "Listen to this"},
+                    {"type": "media", "mime_type": "audio/ogg", "data": encoded_audio},
+                ]
+            )
+        ]
+        mock_llm = unittest.mock.MagicMock()
+        llm_bot.llm = mock_llm
+        mock_llm.get_num_tokens.return_value = 1
+
+        # Act
+        result = llm_bot.count_tokens(messages)
+
+        # Assert
+        self.assertEqual(result, 256 + 1)
+        mock_llm.get_num_tokens.assert_called_once_with("\n Listen to this")
+
     async def test_generate_feedback_message__success_message(self):
         # Arrange
         mock_config = unittest.mock.MagicMock(spec=Config)


### PR DESCRIPTION

  ### Description
  This PR fixes issue #64, where audio messages were being ignored in the `count_tokens` method. This caused voice messages to contribute zero tokens to the context window limit, potentially leading to overflows.

  ### Changes
  - Added token counting for `media` items with audio MIME types.
  - Implemented heuristic duration estimation: (binary_size / 2000 bytes/s) * 32 tokens/s.
  - Added unit tests to verify the calculation.
  - Added a TODO for future LLM-based tokenization improvements.

  ### Verification
  - New test `test_count_tokens__with_audio_media` passed.
  - Full suite (119 tests) passed.

Closes #64 