### PR TITLE
 Refactor count_tokens to use native get_num_tokens_from_messages

### DIFF
--- a/manolo_bot/ai/llmbot.py
+++ b/manolo_bot/ai/llmbot.py
@@ -695,36 +695,12 @@ class LLMBot:
 
     def count_tokens(self, messages: list[BaseMessage]) -> int:
         """
-        Count the number of tokens in the messages.
+        Count the number of tokens in the messages using the LLM provider's native method.
+
         :param messages: List of messages
         :return: Number of tokens
         """
-        extra_tokens = 0
-        context_text = ""
-        for message in messages:
-            if isinstance(message.content, list):
-                for item in message.content:
-                    if item.get("type") == "text":
-                        context_text += "\n " + item.get("text")
-                    elif item.get("type") == "image_url":
-                        # TODO: Use an LLM-based method to get the image token count.
-                        extra_tokens += 258  # using gemini image context size
-                    elif item.get("type") == "media" and "audio" in item.get("mime_type", ""):
-                        # TODO: Use an LLM-based method to get the audio token count.
-                        # Estimate audio duration from raw binary size (assuming typical OGG voice at ~16kbps)
-                        # Then compute duration * 32 (Gemini tokenization rate for audio)
-                        audio_data = item.get("data", "")
-                        if audio_data:
-                            try:
-                                binary_size = len(base64.b64decode(audio_data))
-                                duration = binary_size / 2000  # 16kbps = 2000 bytes/s
-                                extra_tokens += int(duration * 32)
-                            except Exception as e:
-                                logging.error(f"Error estimating audio tokens: {e}")
-            else:
-                context_text += "\n " + message.content
-
-        return self.llm.get_num_tokens(context_text) + extra_tokens
+        return self.llm.get_num_tokens_from_messages(messages)
 
     async def generate_feedback_message(self, prompt: str, max_length: int = 200, chat_id: int | None = None) -> str:
         """

--- a/tests/ai_tests/test_llmagent.py
+++ b/tests/ai_tests/test_llmagent.py
@@ -16,6 +16,7 @@ class TestLlmAgent(unittest.IsolatedAsyncioTestCase):
         mock_llm.bind_tools.return_value = mock_llm
         # Ensure token counting works in tests
         mock_llm.get_num_tokens = MagicMock(return_value=10)
+        mock_llm.get_num_tokens_from_messages = MagicMock(return_value=10)
 
         mock_config = MagicMock(spec=Config)
         mock_config.ollama_model = "test_model"
@@ -70,6 +71,7 @@ class TestLlmAgent(unittest.IsolatedAsyncioTestCase):
 
         mock_llm = MagicMock()
         mock_llm.get_num_tokens = MagicMock(return_value=10)
+        mock_llm.get_num_tokens_from_messages = MagicMock(return_value=10)
         system_instructions = [SystemMessage(content="You are a helpful assistant")]
 
         # Act

--- a/tests/ai_tests/test_llmbot.py
+++ b/tests/ai_tests/test_llmbot.py
@@ -17,6 +17,7 @@ class TestLlmBot(unittest.IsolatedAsyncioTestCase):
         mock_llm.bind_tools.return_value = mock_llm
         # Ensure token counting works in tests by returning an int, not a mock
         mock_llm.get_num_tokens = MagicMock(return_value=10)
+        mock_llm.get_num_tokens_from_messages = MagicMock(return_value=10)
 
         mock_config = MagicMock(spec=Config)
         mock_config.ollama_model = "test_model"
@@ -109,6 +110,7 @@ class TestLlmBot(unittest.IsolatedAsyncioTestCase):
         mock_llm = MagicMock()
         mock_llm.ainvoke = AsyncMock(return_value=AIMessage(content="Analysis"))
         mock_llm.get_num_tokens = MagicMock(return_value=10)
+        mock_llm.get_num_tokens_from_messages = MagicMock(return_value=10)
 
         mock_storage = MagicMock(spec=BaseDocumentStorage)
         mock_storage.store = AsyncMock()
@@ -229,15 +231,15 @@ class TestLlmBot(unittest.IsolatedAsyncioTestCase):
         llm_bot = self.get_basic_llm_bot()
         messages = [HumanMessage(content="Hello"), HumanMessage(content="World")]
         llm_bot.llm = unittest.mock.MagicMock()
-        llm_bot.llm.get_num_tokens = unittest.mock.MagicMock()
-        llm_bot.llm.get_num_tokens.return_value = 2
+        llm_bot.llm.get_num_tokens_from_messages = unittest.mock.MagicMock()
+        llm_bot.llm.get_num_tokens_from_messages.return_value = 2
 
         # Act
         result = llm_bot.count_tokens(messages)
 
         # Assert
         self.assertEqual(result, 2)
-        llm_bot.llm.get_num_tokens.assert_called_once_with("\n Hello\n World")
+        llm_bot.llm.get_num_tokens_from_messages.assert_called_once_with(messages)
 
     def test_count_tokens__with_list_content(self):
         # Arrange
@@ -253,14 +255,14 @@ class TestLlmBot(unittest.IsolatedAsyncioTestCase):
         ]
         mock_llm = unittest.mock.MagicMock()
         llm_bot.llm = mock_llm
-        mock_llm.get_num_tokens.return_value = 3
+        mock_llm.get_num_tokens_from_messages.return_value = 3
 
         # Act
         result = llm_bot.count_tokens(messages)
 
         # Assert
-        self.assertEqual(result, 258 + 3)  # image (258) + text (3)
-        mock_llm.get_num_tokens.assert_called_once_with("\n Hello\n Test")
+        self.assertEqual(result, 3)
+        mock_llm.get_num_tokens_from_messages.assert_called_once_with(messages)
 
     def test_count_tokens__with_audio_media(self):
         # Arrange
@@ -281,14 +283,14 @@ class TestLlmBot(unittest.IsolatedAsyncioTestCase):
         ]
         mock_llm = unittest.mock.MagicMock()
         llm_bot.llm = mock_llm
-        mock_llm.get_num_tokens.return_value = 1
+        mock_llm.get_num_tokens_from_messages.return_value = 1
 
         # Act
         result = llm_bot.count_tokens(messages)
 
         # Assert
-        self.assertEqual(result, 256 + 1)
-        mock_llm.get_num_tokens.assert_called_once_with("\n Listen to this")
+        self.assertEqual(result, 1)
+        mock_llm.get_num_tokens_from_messages.assert_called_once_with(messages)
 
     async def test_generate_feedback_message__success_message(self):
         # Arrange
@@ -348,6 +350,7 @@ class TestLlmBot(unittest.IsolatedAsyncioTestCase):
         llm_bot.llm = MagicMock()
         llm_bot.llm.ainvoke = AsyncMock()
         llm_bot.llm.get_num_tokens = MagicMock(return_value=10)
+        llm_bot.llm.get_num_tokens_from_messages = MagicMock(return_value=10)
 
         chat_id = 1
         text = "Check this audio"


### PR DESCRIPTION

Replace the manual token counting logic in `LLMBot.count_tokens` with a delegation to `self.llm.get_num_tokens_from_messages(messages)`, which is the native LangChain method for counting tokens from message structures.

### Changes

- **`manolo_bot/ai/llmbot.py`** — Replaced the 30-line `count_tokens` method (manual text concatenation, hardcoded Gemini-specific image/audio token values) with a single delegation to `get_num_tokens_from_messages`.
- **`tests/ai_tests/test_llmbot.py`** — Updated the three `count_tokens` tests to mock `get_num_tokens_from_messages` and assert it was called with the full message list. Also added the mock in helper methods to keep `truncate_chat_context` working.
- **`tests/ai_tests/test_llmagent.py`** — Same mock additions for the agent tests that call `truncate_chat_context`.

### Benefits

- Model-agnostic: no hardcoded Gemini-specific image (258) or audio (32×) token values
- Properly accounts for per-message structural overhead (roles, formatting)
- Delegates multimodal tokenization to the LLM provider's own implementation
- Dramatically simplifies the code (~30 lines → 3 lines)

Closes #66 