### PR TITLE
Add SkillsMiddleware support and harden deep_agent paths (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Default is `local_fs`. The `local_fs` backend persists scratch files per chat un
 The `in_memory` backend keeps the virtual filesystem in process memory, scoped per
 `(bot_uuid, chat_id)`; state is cleared on `clean_context()` or process restart.
 
+`DEEP_AGENT_SKILLS_PATHS`: Comma-separated list of skill source paths for the `deep_agent` mode; skills are loaded into the agent's system prompt via progressive disclosure.
+
 #### Enabling image Generation with Stable Diffusion
 
 `WEBUI_SD_API_URL`: you can define a Stable Diffusion Web UI API URL for image generation. If this option is enabled the

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -16,6 +16,11 @@ AI Components
    :undoc-members:
    :show-inheritance:
 
+.. automodule:: manolo_bot.ai.llmdeepagent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. automodule:: manolo_bot.ai.mcp_manager
    :members:
    :undoc-members:
@@ -40,6 +45,11 @@ Storage Components
    :show-inheritance:
 
 .. automodule:: manolo_bot.storage.deep_agent_backends.filesystem_backend
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: manolo_bot.storage.deep_agent_backends.skills_filesystem_backend
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/usage_app.rst
+++ b/docs/source/usage_app.rst
@@ -143,6 +143,7 @@ Agent and Tools
      ``$HOME/.local/share/manolo_bot/workspace`` with mode ``0700``.
 
 * `DEEP_AGENT_BACKEND`: Filesystem backend type for the `deep_agent` mode (`in_memory` or `local_fs`, default `local_fs`). The `local_fs` backend persists scratch files per chat and refuses to delete anything outside the workspace. The `in_memory` backend keeps the virtual filesystem in process memory, scoped per ``(bot_uuid, chat_id)``; state is cleared on ``clean_context()`` or process restart.
+* `DEEP_AGENT_SKILLS_PATHS`: Comma-separated list of skill source paths for the `deep_agent` mode. Each entry is a bare path to a directory whose subdirectories contain `SKILL.md` files, or `<path>::LABEL=<text>` to give the source a label. Skills are loaded into the agent's system prompt via progressive disclosure (metadata at startup, full `SKILL.md` bodies on demand via `read_file`). Empty by default; no skills middleware is added when unset. See the Agent Skills spec at https://agentskills.io/specification for the `SKILL.md` frontmatter format (`name` and `description` required).
 
 Search Configuration
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/usage_library.rst
+++ b/docs/source/usage_library.rst
@@ -137,6 +137,72 @@ The virtual filesystem uses a pluggable backend, similar to how message and docu
 
 If no backend is provided, ``LLMDeepAgent`` falls back to an in-memory ``StateBackend``.
 
+Skills (progressive disclosure)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The deep agent loads Agent Skills (capability bundles described by ``SKILL.md`` files) via ``deepagents``' ``SkillsMiddleware``. Two optional parameters on ``LLMDeepAgent.__init__`` mirror the backend-injection pattern used by ``backend=``:
+
+* ``skills_paths``: A sequence of source paths. Each entry is a bare path (``str``) or a ``(path, label)`` tuple. Bare paths get a default label derived from the final path component. The optional ``<path>::LABEL=<text>`` syntax is also accepted and split into a tuple under the hood, so the same string format works for env-var-driven configuration.
+* ``skills_backend``: An instance of :class:`BaseSkillsBackend` (typically :class:`SkillsFilesystemDeepAgentBackend`) — explicitly injected by the caller. ``LLMDeepAgent`` does **not** instantiate a skills backend itself: if you don't pass one, ``SkillsMiddleware`` is omitted entirely, even when ``skills_paths`` is set. A ``WARNING`` is logged so the misconfiguration is loud, not silent.
+
+When ``skills_paths`` is empty (or neither ``skills_paths`` nor ``bot_config.deep_agent_skills_paths`` is set), no ``SkillsMiddleware`` is added and behavior is identical to a deep-agent instance without skills.
+
+Skills are operator-provided, not per-chat state. They are intentionally **not** cleared by ``clean_context()`` — wiping operator content when a user runs ``/flushcontext`` would be destructive. ``SkillsMiddleware`` owns its own per-session lifecycle via the ``before_agent`` hook, so a fresh chat context simply re-reads skill metadata on the next session.
+
+The skills backend
+++++++++++++++++++
+
+Skills are *global* — shared across all chats and bot instances in the same process. The canonical wrapper is :class:`SkillsFilesystemDeepAgentBackend` (a :class:`BaseSkillsBackend` subclass), which wraps ``deepagents.backends.filesystem.FilesystemBackend`` with ``virtual_mode=False`` so absolute skill source paths (e.g. ``/etc/manolo_bot/skills``) resolve directly on the host filesystem. The unrestricted read access is safe because the wrapper is only handed to ``SkillsMiddleware``, which only calls ``ls()`` and ``download_files()`` (read-only) at the configured source paths.
+
+For a standalone bot, construct one instance at module load and pass it to every agent:
+
+.. code-block:: python
+
+   from manolo_bot.storage.deep_agent_backends.skills_filesystem_backend import (
+       SkillsFilesystemDeepAgentBackend,
+   )
+
+   skills_backend = SkillsFilesystemDeepAgentBackend()
+   llm_bot = LLMDeepAgent(
+       ...,
+       skills_paths=["/etc/manolo_bot/skills", ("$HOME/.local/share/manolo_bot/skills", "User")],
+       skills_backend=skills_backend,
+   )
+
+To use a custom workspace path (e.g. relative paths anchored at a project root):
+
+.. code-block:: python
+
+   skills_backend = SkillsFilesystemDeepAgentBackend(workspace_path="/opt/mybot/skills")
+   llm_bot = LLMDeepAgent(
+       ...,
+       skills_paths=["/opt/mybot/skills", ("/etc/manolo_bot/skills", "System")],
+       skills_backend=skills_backend,
+   )
+
+For a custom backend (e.g. Redis-backed, S3, in-memory), subclass :class:`BaseSkillsBackend` and implement ``.backend`` (a ``BackendProtocol``) and an async ``.clear()``. ``clear()`` should typically be a no-op — skills are operator-provided and must never be wiped by ``clean_context()``:
+
+.. code-block:: python
+
+   from manolo_bot.storage.deep_agent_backends.base import BaseSkillsBackend
+
+   class RedisSkillsBackend(BaseSkillsBackend):
+       def __init__(self, client):
+           self._client = client
+           self._backend = ...  # your BackendProtocol implementation
+
+       @property
+       def backend(self):
+           return self._backend
+
+       async def clear(self):
+           pass  # operator-provided content; never wipe
+
+Skill-file routing for the agent's runtime tools
++++++++++++++++++++++++++++++++++++++++++++++++++
+
+When ``skills_paths`` is configured, ``LLMDeepAgent`` wraps the agent's main filesystem backend with a :class:`deepagents.backends.composite.CompositeBackend` that adds one route per skill source. Each route's backend is a sandboxed :class:`FilesystemBackend` rooted at that source with ``virtual_mode=True``. This lets the agent's runtime ``read_file`` / ``ls`` / ``glob`` / ``grep`` tools access skill files at their absolute paths — without it, the chat-scoped backend's ``virtual_mode=True`` root would reject any path outside the chat workspace and ``read_file`` calls to skill files would silently fail with "file not found". The per-chat scratch behaviour for non-skill paths is unchanged.
+
 .. code-block:: python
 
    import asyncio
@@ -185,6 +251,29 @@ If no backend is provided, ``LLMDeepAgent`` falls back to an in-memory ``StateBa
 
    if __name__ == "__main__":
        asyncio.run(main())
+
+To enable skills in your own bot, construct a skills backend and pass it explicitly:
+
+.. code-block:: python
+
+   from manolo_bot.ai.llmdeepagent import LLMDeepAgent
+   from manolo_bot.storage.deep_agent_backends.skills_filesystem_backend import (
+       SkillsFilesystemDeepAgentBackend,
+   )
+
+   skills_backend = SkillsFilesystemDeepAgentBackend()
+   llm_bot = LLMDeepAgent(
+       llm,
+       bot_config,
+       system_instructions,
+       messages_storage,
+       backend=backend,
+       skills_paths=[
+           "/etc/manolo_bot/skills",
+           ("/opt/skills/research", "Research"),
+       ],
+       skills_backend=skills_backend,
+   )
 
 Simple Alternative: LLMBot
 --------------------------

--- a/env.example
+++ b/env.example
@@ -38,6 +38,14 @@ TELEGRAM_BOT_USERNAME=Your telegram bot username
 # DEEP_AGENT_WORKSPACE_PATH=/tmp/manolo_bot/workspace
 # DEEP_AGENT_BACKEND=local_fs # Available: in_memory, local_fs (default)
 
+# Deep Agent Skills (progressive disclosure)
+# Comma-separated list of skill source paths. Each entry is either a bare path
+# to a directory whose subdirectories contain SKILL.md files, or a path with
+# a label suffix: `<path>::LABEL=<text>`. The label renders as the section
+# header in the agent's system prompt (e.g. **User Skills**).
+# Example: DEEP_AGENT_SKILLS_PATHS=/etc/manolo_bot/skills::LABEL=User,$HOME/.local/share/manolo_bot/skills
+# DEEP_AGENT_SKILLS_PATHS=
+
 # Search Configuration
 # USE_TAVILY_SEARCH=False
 # TAVILY_SEARCH_KEY=Your Tavily API key

--- a/manolo_bot/ai/config.py
+++ b/manolo_bot/ai/config.py
@@ -50,6 +50,9 @@ class BotConfig:
     deep_agent_workspace_path: str = ""
     deep_agent_backend: str = "local_fs"
 
+    # Deep Agent skills (progressive-disclosure capability bundles loaded via SkillsMiddleware)
+    deep_agent_skills_paths: list[str] = field(default_factory=list)
+
 
 @dataclass
 class LLMConfig:

--- a/manolo_bot/ai/llmdeepagent.py
+++ b/manolo_bot/ai/llmdeepagent.py
@@ -1,9 +1,12 @@
 import logging
-from typing import TYPE_CHECKING
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
 
 from deepagents import create_deep_agent
 from deepagents.backends import StateBackend
-from deepagents.middleware import FilesystemMiddleware
+from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.middleware import FilesystemMiddleware, SkillsMiddleware
 from langchain.agents.middleware import TodoListMiddleware
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import BaseMessage
@@ -12,12 +15,47 @@ from langchain_core.tools import BaseTool
 from manolo_bot.ai.config import BotConfig
 from manolo_bot.ai.llmagent import LLMAgent
 from manolo_bot.ai.tools import get_all_tools
-from manolo_bot.storage.deep_agent_backends.base import BaseDeepAgentBackend
+from manolo_bot.storage.deep_agent_backends.base import (
+    BaseDeepAgentBackend,
+    BaseSkillsBackend,
+)
 from manolo_bot.storage.documents.base import BaseDocumentStorage
 from manolo_bot.storage.messages.base import BaseMessagesStorage
 
 if TYPE_CHECKING:
     from deepagents.backends.protocol import BackendProtocol
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_skills_sources(
+    raw_paths: Sequence[str | tuple[str, str]] | None,
+) -> list[str | tuple[str, str]]:
+    """
+    Resolve a list of raw skill source paths into the shape deepagents expects.
+
+    Each entry is either a bare path (``str``), a ``(path, label)`` tuple, or
+    a ``<path>::LABEL=<text>`` string which is split into a tuple. Tuples are
+    passed through unchanged. The ``::LABEL=`` syntax is a convenience for
+    env-var-driven configuration; deepagents itself only accepts bare
+    paths or ``(path, label)`` tuples.
+    """
+    if not raw_paths:
+        return []
+    resolved: list[str | tuple[str, str]] = []
+    for entry in raw_paths:
+        if not entry:
+            continue
+        if isinstance(entry, tuple):
+            resolved.append(entry)
+            continue
+        if "::LABEL=" in entry:
+            path, _, label = entry.partition("::LABEL=")
+            if label.strip():
+                resolved.append((path, label.strip()))
+                continue
+        resolved.append(entry)
+    return resolved
 
 
 class LLMDeepAgent(LLMAgent):
@@ -28,6 +66,7 @@ class LLMDeepAgent(LLMAgent):
     - To-do list planning (TodoListMiddleware)
     - Virtual filesystem (FilesystemMiddleware + StateBackend)
     - Sub-agents (via create_deep_agent subagents parameter)
+    - Skills (progressive disclosure via SkillsMiddleware)
 
     The deep agent harness has its own internal system prompt (planning,
     filesystem, sub-agent instructions). The bot's character/persona
@@ -37,7 +76,25 @@ class LLMDeepAgent(LLMAgent):
 
     The virtual filesystem backend is injected from outside
     (see :meth:`main.instance_llm_bot`), keeping the class decoupled
-    from chat-specific path logic.
+    from chat-specific path logic. Skills follow the same explicit
+    injection pattern: ``LLMDeepAgent`` does **not** instantiate a
+    skills backend itself. Pass ``skills_paths`` together with an
+    explicit ``skills_backend`` wrapper (typically a
+    :class:`SkillsFilesystemDeepAgentBackend` constructed once at
+    module load and shared across every chat in the process). If
+    ``skills_backend`` is ``None`` the ``SkillsMiddleware`` is omitted
+    entirely, even when ``skills_paths`` is set.
+
+    Skills are operator-provided, not per-chat state, and are
+    intentionally **not** cleared by :meth:`clean_context`.
+
+    When ``skills_paths`` is configured, the agent's main filesystem
+    backend is wrapped with a :class:`CompositeBackend` that routes
+    each configured skill source to its own sandboxed
+    :class:`FilesystemBackend` rooted at that source. This lets the
+    agent's runtime ``read_file`` / ``ls`` tools access skill files at
+    their absolute paths — the per-chat backend's ``virtual_mode=True``
+    root would otherwise reject any path outside the chat workspace.
     """
 
     bind_tools_on_init = False
@@ -52,6 +109,8 @@ class LLMDeepAgent(LLMAgent):
         documents_storage: BaseDocumentStorage | None = None,
         system_instructions_mapping=None,
         backend: BaseDeepAgentBackend | None = None,
+        skills_paths: Sequence[str | tuple[str, str]] | None = None,
+        skills_backend: BaseSkillsBackend | None = None,
     ) -> None:
         super().__init__(
             llm,
@@ -65,6 +124,51 @@ class LLMDeepAgent(LLMAgent):
         self._backend_wrapper = backend
         self._backend: BackendProtocol = backend.backend if backend else StateBackend()
         self.agent = None
+        # Skills backend is **explicitly injected** by the caller — same shape
+        # as ``backend=``. If absent, SkillsMiddleware is omitted entirely
+        # (no implicit default, no singleton). The ABC
+        # ``BaseSkillsBackend`` enforces the ``.backend`` and ``.clear()``
+        # contract at type-check / instantiation time, mirroring how
+        # ``BaseDeepAgentBackend`` does it for the main backend.
+        self._skills_backend: BackendProtocol | None = skills_backend.backend if skills_backend is not None else None
+        # Resolve skill sources eagerly (pure parsing, no I/O): prefer the
+        # explicit ctor argument, fall back to bot_config, else empty.
+        if skills_paths is not None:
+            self._resolved_skills_sources: list[str | tuple[str, str]] = _resolve_skills_sources(skills_paths)
+        elif bot_config.deep_agent_skills_paths:
+            self._resolved_skills_sources = _resolve_skills_sources(bot_config.deep_agent_skills_paths)
+        else:
+            self._resolved_skills_sources = []
+        if self._resolved_skills_sources and self._skills_backend is None:
+            # Surfacing this loudly avoids the silent-no-skills failure mode of
+            # earlier drafts where sources were configured but no backend was
+            # wired, so the bot saw no skill metadata at all.
+            logger.warning(
+                "skills_paths is configured (%d source(s)) but no skills_backend "
+                "was passed; SkillsMiddleware will be omitted and skills will "
+                "not be loaded. Pass skills_backend=SkillsFilesystemDeepAgentBackend(...) "
+                "to enable skills.",
+                len(self._resolved_skills_sources),
+            )
+
+        # Wrap the main backend with skill-source routes so the agent's
+        # FilesystemMiddleware (read_file, ls, glob, grep) can access skill files
+        # at the configured paths. Without this, the per-chat backend's
+        # virtual_mode=True root rejects any path outside the chat workspace and
+        # the bot's read_file calls to skill paths return "file not found".
+        # Each route gets its own FilesystemBackend rooted at the source with
+        # virtual_mode=True so CompositeBackend's prefix-stripping lands the
+        # resolved path back inside the source directory.
+        if self._resolved_skills_sources:
+            skill_routes: dict[str, BackendProtocol] = {}
+            for source in self._resolved_skills_sources:
+                skill_path = source[0] if isinstance(source, tuple) else source
+                route_prefix = skill_path.rstrip("/") + "/"
+                skill_routes[route_prefix] = FilesystemBackend(
+                    root_dir=skill_path.rstrip("/"),
+                    virtual_mode=True,
+                )
+            self._backend = CompositeBackend(default=self._backend, routes=skill_routes)
 
     async def initialize_async_resources(self) -> None:
         """Initialize async resources and create deep agent with all tools."""
@@ -76,16 +180,28 @@ class LLMDeepAgent(LLMAgent):
 
         instructions_text = self._system_instructions[0].content if self._system_instructions else ""
 
-        self.agent = create_deep_agent(
-            model=self.llm,
-            tools=tools,
-            system_prompt=instructions_text,
-            middleware=[
-                FilesystemMiddleware(backend=self._backend),
-                TodoListMiddleware(),
-            ],
-            subagents=[],
-        )
+        middleware: list[Any] = [
+            FilesystemMiddleware(backend=self._backend),
+            TodoListMiddleware(),
+        ]
+        # SkillsMiddleware is only included when both skill sources and an
+        # explicit skills backend wrapper are present. The wrapper is constructed
+        # by the caller (typically main.py instantiates one
+        # SkillsFilesystemDeepAgentBackend and shares it across every chat).
+        # Constructing SkillsMiddleware explicitly (instead of passing
+        # `skills=[...]` to create_deep_agent) keeps the skills backend
+        # independent of the agent's main filesystem backend.
+        if self._resolved_skills_sources and self._skills_backend is not None:
+            middleware.append(SkillsMiddleware(backend=self._skills_backend, sources=self._resolved_skills_sources))
+
+        create_kwargs: dict[str, Any] = {
+            "model": self.llm,
+            "tools": tools,
+            "system_prompt": instructions_text,
+            "middleware": middleware,
+            "subagents": [],
+        }
+        self.agent = create_deep_agent(**create_kwargs)
         logging.debug(f"Deep agent created with {len(tools)} tools")
 
     def _base_messages(self) -> list[BaseMessage]:
@@ -96,5 +212,10 @@ class LLMDeepAgent(LLMAgent):
 
     async def clean_context(self) -> None:
         await super().clean_context()
+        # Skills are operator-provided, not per-chat state — do not clear the
+        # skills backend here. Clearing a FilesystemDeepAgentBackend used for
+        # skills would delete the skills directory; clearing a MemoryDeepAgentBackend
+        # would orphan the in-memory skill cache from re-discovery. SkillsMiddleware
+        # owns its own per-session lifecycle via the `before_agent` hook.
         if self._backend_wrapper:
             await self._backend_wrapper.clear()

--- a/manolo_bot/config.py
+++ b/manolo_bot/config.py
@@ -106,6 +106,9 @@ class Config(EnvModel):
     )
     deep_agent_backend = StringField("DEEP_AGENT_BACKEND", default="local_fs", allowed_values=["in_memory", "local_fs"])
 
+    # Deep Agent skills (comma-separated paths; entries may be `<path>::LABEL=<text>`)
+    deep_agent_skills_paths = StringListField("DEEP_AGENT_SKILLS_PATHS", default=[])
+
     logging_level = StringField(
         "LOGGING_LEVEL", default="INFO", allowed_values=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
     )

--- a/manolo_bot/main.py
+++ b/manolo_bot/main.py
@@ -18,6 +18,9 @@ from manolo_bot.ai.llmdeepagent import LLMDeepAgent
 from manolo_bot.config import Config
 from manolo_bot.storage.deep_agent_backends.filesystem_backend import FilesystemDeepAgentBackend
 from manolo_bot.storage.deep_agent_backends.memory_backend import MemoryDeepAgentBackend
+from manolo_bot.storage.deep_agent_backends.skills_filesystem_backend import (
+    SkillsFilesystemDeepAgentBackend,
+)
 from manolo_bot.storage.documents.file_storage import FileDocumentsStorage
 from manolo_bot.storage.messages.memory_storage import MemoryMessagesStorage
 from manolo_bot.telegram.utils import (
@@ -142,6 +145,16 @@ flush_context_failure_instructions = f"Generate a short, friendly message in {co
 system_instructions = [SystemMessage(content=instructions), AIMessage(content="ok!")]
 message_queue = asyncio.Queue()
 
+# Shared skills backend — operator-provided, versioned, auditable capability bundles
+# described by SKILL.md files. One instance is reused across every chat in this
+# process so the same skills are visible to every conversation. ``LLMDeepAgent``
+# does not instantiate skills backends itself; it requires the caller to pass
+# one explicitly (same pattern as the main ``backend=`` parameter). When
+# ``DEEP_AGENT_SKILLS_PATHS`` is empty, the backend is still constructed but
+# ``SkillsMiddleware`` is omitted from the agent's middleware list because
+# ``skills_paths`` resolves to an empty list.
+skills_backend = SkillsFilesystemDeepAgentBackend()
+
 llm_config = LLMConfig(
     google_api_key=config.google_api_key,
     google_api_model=config.google_api_model,
@@ -176,6 +189,7 @@ bot_config = BotConfig(
     max_voice_size=config.max_voice_size,
     deep_agent_workspace_path=config.deep_agent_workspace_path,
     deep_agent_backend=config.deep_agent_backend,
+    deep_agent_skills_paths=config.deep_agent_skills_paths,
 )
 
 
@@ -209,6 +223,8 @@ async def instance_llm_bot(chat_id: int) -> LLMBot:
             documents_storage=document_storage,
             system_instructions_mapping=instructions_mapping,
             backend=backend,
+            skills_paths=bot_config.deep_agent_skills_paths,
+            skills_backend=skills_backend,
         )
     elif config.effective_ai_mode == "agent":
         llm_bot = LLMAgent(

--- a/manolo_bot/storage/deep_agent_backends/base.py
+++ b/manolo_bot/storage/deep_agent_backends/base.py
@@ -45,3 +45,37 @@ class BaseDeepAgentBackend(abc.ABC):
         For filesystem backends, this removes the chat directory.
         """
         pass
+
+
+class BaseSkillsBackend(abc.ABC):
+    """Abstract base class for deep-agent skills backends.
+
+    Skills are operator-provided, versioned, auditable capability bundles
+    described by ``SKILL.md`` files. They are *global* (shared across all
+    chats and bot instances in the same process) and must never be cleared
+    by ``LLMDeepAgent.clean_context()``.
+
+    This class is intentionally **not** scoped by ``(bot_uuid, chat_id)`` —
+    it parallels :class:`BaseDeepAgentBackend` but for the *global* (not
+    per-chat) namespace. Subclasses provide a single backend instance that
+    every chat shares.
+
+    Library users may subclass this to provide custom storage (Redis, S3,
+    in-memory, etc.) — same extension model as :class:`BaseDeepAgentBackend`.
+    """
+
+    @property
+    @abc.abstractmethod
+    def backend(self) -> "BackendProtocol":
+        """The underlying :class:`BackendProtocol` instance used by ``SkillsMiddleware``."""
+        ...
+
+    @abc.abstractmethod
+    async def clear(self) -> None:
+        """Clear the backend state.
+
+        Skills are operator-provided, not per-chat state. Implementations
+        should typically be a no-op — wiping operator content when a user
+        runs ``/flushcontext`` would be destructive and surprising.
+        """
+        ...

--- a/manolo_bot/storage/deep_agent_backends/filesystem_backend.py
+++ b/manolo_bot/storage/deep_agent_backends/filesystem_backend.py
@@ -1,32 +1,92 @@
 import os
+import re
 import shutil
 
 from deepagents.backends.filesystem import FilesystemBackend
 
 from manolo_bot.storage.deep_agent_backends.base import BaseDeepAgentBackend
 
+# Path-traversal characters are forbidden in bot_uuid. The character class is
+# chosen to match realistic identifiers (alphanumeric, dash, underscore) while
+# excluding ``/``, ``.``, and everything else that could escape the chat
+# directory under ``workspace_path``. ``bot_uuid`` is operator-provided via
+# ``BOT_UUID`` — a typo or attacker-controlled env var must not be able to
+# trick ``/flushcontext`` (which calls ``clear()`` → ``shutil.rmtree``) into
+# deleting directories outside the configured workspace.
+_BOT_UUID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+
 
 class FilesystemDeepAgentBackend(BaseDeepAgentBackend):
     """
     Filesystem-based implementation of the deep agent filesystem backend.
 
-    Builds a per-chat filesystem path from bot_uuid and chat_id,
-    mirroring the pattern used by FileDocumentsStorage.
+    Builds a per-chat filesystem path from ``bot_uuid`` and ``chat_id``,
+    mirroring the pattern used by :class:`FileDocumentsStorage`.
 
-    Security note: ``workspace_path`` should be a directory only the bot
-    process can read. The default (``/tmp/manolo_bot/workspace``) lives
-    under the system temp directory, which on Linux is world-readable;
-    on shared hosts set ``DEEP_AGENT_WORKSPACE_PATH`` to a private path
+    Security model — defense in depth, two layers:
+
+    * **Layer 1 — input validation at construction time** (fail-fast).
+      ``bot_uuid`` is required to match ``[A-Za-z0-9_-]+`` (refuses ``/``,
+      ``..``, control characters, etc.). ``workspace_path`` is required to
+      be an absolute path. A misconfigured operator gets a ``ValueError``
+      at startup, before any agent can run.
+    * **Layer 2 — containment check at use time** (defense in depth).
+      ``_build_backend()`` and ``clear()`` resolve the constructed
+      ``chat_path`` and verify it is still under ``workspace_path``. This
+      catches symlink-based escapes that pass Layer 1 (the workspace root
+      itself contains a symlink pointing outside) and runtime mutations
+      of ``_workspace_path``.
+
+    Note: ``workspace_path`` should be a directory only the bot process
+    can read. The default (``/tmp/manolo_bot/workspace``) lives under the
+    system temp directory, which on Linux is world-readable; on shared
+    hosts set ``DEEP_AGENT_WORKSPACE_PATH`` to a private path
     (e.g. ``~/.local/share/manolo_bot/workspace`` with mode ``0700``).
     """
 
     def __init__(self, bot_uuid: str, chat_id: int, workspace_path: str, virtual_mode: bool = True) -> None:
+        # Layer 1: input validation.
+        if not isinstance(bot_uuid, str) or not _BOT_UUID_PATTERN.fullmatch(bot_uuid):
+            raise ValueError(
+                f"Invalid bot_uuid {bot_uuid!r}: must match [A-Za-z0-9_-]+ "
+                "(refuses '/', '..', and other path-traversal characters)."
+            )
+        if not isinstance(workspace_path, str) or not workspace_path or not os.path.isabs(workspace_path):
+            raise ValueError(f"workspace_path must be a non-empty absolute path; got {workspace_path!r}.")
         self._workspace_path = workspace_path
         self._virtual_mode = virtual_mode
         super().__init__(bot_uuid, chat_id)
 
-    def _build_backend(self) -> FilesystemBackend:
+    def _safe_chat_path(self) -> str:
+        """Compute the chat path and verify it resolves under ``workspace_path``.
+
+        Returns the resolved path. Raises ``ValueError`` if the chat path
+        escapes the workspace — caller should treat this as a hard error
+        and not attempt ``shutil.rmtree`` or any other filesystem op.
+
+        This is Layer 2 of the security model. ``os.path.realpath`` follows
+        symlinks, so a workspace whose root itself contains a symlink
+        pointing outside is caught here even though Layer 1 (which only
+        inspects ``bot_uuid``) would have let it through.
+        """
         chat_path = os.path.join(self._workspace_path, self.bot_uuid, str(self.chat_id))
+        resolved_workspace = os.path.realpath(self._workspace_path)
+        resolved_chat = os.path.realpath(chat_path)
+        try:
+            common = os.path.commonpath([resolved_workspace, resolved_chat])
+        except ValueError as exc:
+            raise ValueError(
+                f"chat_path {chat_path!r} not under workspace_path {self._workspace_path!r}: {exc}"
+            ) from exc
+        if common != resolved_workspace:
+            raise ValueError(
+                f"Refusing to operate on chat_path {chat_path!r}: resolved "
+                f"outside workspace_path {self._workspace_path!r}."
+            )
+        return resolved_chat
+
+    def _build_backend(self) -> FilesystemBackend:
+        chat_path = self._safe_chat_path()
         return FilesystemBackend(root_dir=chat_path, virtual_mode=self._virtual_mode)
 
     @property
@@ -34,6 +94,8 @@ class FilesystemDeepAgentBackend(BaseDeepAgentBackend):
         return self._backend
 
     async def clear(self) -> None:
-        chat_path = os.path.join(self._workspace_path, self.bot_uuid, str(self.chat_id))
+        # Layer 2 catches a tampered ``_workspace_path`` or a workspace
+        # whose realpath resolves outside the operator-intended root.
+        chat_path = self._safe_chat_path()
         if os.path.exists(chat_path):
             shutil.rmtree(chat_path)

--- a/manolo_bot/storage/deep_agent_backends/skills_filesystem_backend.py
+++ b/manolo_bot/storage/deep_agent_backends/skills_filesystem_backend.py
@@ -1,0 +1,73 @@
+"""Filesystem-based backend for the deep agent's SkillsMiddleware.
+
+Skills are operator-provided, versioned, auditable capability bundles described
+by ``SKILL.md`` files. They are *global* (shared across all chats and bot
+instances in the same process) and must never be cleared by ``clean_context``
+— clearing a filesystem-backed skills store would delete operator content
+when a user runs ``/flushcontext``.
+
+Unlike :class:`FilesystemDeepAgentBackend`, this class is intentionally
+**not** scoped by ``(bot_uuid, chat_id)``. It wraps ``FilesystemBackend``
+with ``virtual_mode=False`` so the configured skill source paths
+(``DEEP_AGENT_SKILLS_PATHS``) can be at any absolute location on the host
+filesystem, not just inside a per-chat workspace subdirectory.
+
+``virtual_mode=False`` is safe here because this instance is handed exclusively
+to ``SkillsMiddleware``, which only calls ``ls()`` and ``download_files()``
+(read-only) at the configured source paths. No write/edit/delete is ever
+invoked through this backend.
+"""
+
+from deepagents.backends.filesystem import FilesystemBackend
+
+from manolo_bot.storage.deep_agent_backends.base import BaseSkillsBackend
+
+
+class SkillsFilesystemDeepAgentBackend(BaseSkillsBackend):
+    """Filesystem-backed implementation of :class:`BaseSkillsBackend`.
+
+    One instance is intended to be reused across every agent in the process:
+    :mod:`manolo_bot.main` constructs a single instance at module load and
+    passes it to every ``LLMDeepAgent`` it creates.
+
+    :param workspace_path: Optional root directory for relative skill source
+        paths. Absolute paths in ``DEEP_AGENT_SKILLS_PATHS`` are unaffected.
+        Defaults to ``None`` (uses the process current working directory).
+
+    Example:
+
+        .. code-block:: python
+
+            from manolo_bot.storage.deep_agent_backends.skills_filesystem_backend import (
+                SkillsFilesystemDeepAgentBackend,
+            )
+
+            # Shared — reuse across every chat in the process.
+            skills_backend = SkillsFilesystemDeepAgentBackend()
+            llm_bot = LLMDeepAgent(
+                ...,
+                skills_paths=["/etc/manolo_bot/skills", ("$HOME/.local/share/manolo_bot/skills", "User")],
+                skills_backend=skills_backend,
+            )
+    """
+
+    def __init__(self, workspace_path: str | None = None) -> None:
+        # virtual_mode=False so absolute skill source paths resolve directly
+        # on the host filesystem, regardless of `workspace_path`.
+        self._backend = FilesystemBackend(root_dir=workspace_path, virtual_mode=False)
+
+    @property
+    def backend(self) -> FilesystemBackend:
+        """The underlying :class:`deepagents.backends.filesystem.FilesystemBackend` instance."""
+        return self._backend
+
+    async def clear(self) -> None:
+        """No-op.
+
+        Skills are operator-provided, not per-chat state. They are intentionally
+        not cleared by ``LLMDeepAgent.clean_context()`` — wiping operator content
+        when a user runs ``/flushcontext`` would be destructive and surprising.
+        If a caller really wants to drop skills, they can replace the singleton
+        with a fresh instance.
+        """
+        return None

--- a/tests/ai_tests/test_llmdeepagent.py
+++ b/tests/ai_tests/test_llmdeepagent.py
@@ -1,10 +1,17 @@
+import pathlib
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from deepagents.backends import StateBackend
+from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.middleware import FilesystemMiddleware
+from deepagents.middleware.skills import SkillsMiddleware
 from langchain_core.messages import SystemMessage
 
 from manolo_bot.ai.config import BotConfig
-from manolo_bot.ai.llmdeepagent import LLMDeepAgent
+from manolo_bot.ai.llmdeepagent import LLMDeepAgent, _resolve_skills_sources
+from manolo_bot.storage.deep_agent_backends.base import BaseDeepAgentBackend
 
 
 def _make_config(**overrides) -> BotConfig:
@@ -107,7 +114,8 @@ class TestLLMDeepAgent(unittest.IsolatedAsyncioTestCase):
 
     @patch("manolo_bot.ai.llmagent.create_agent")
     async def test_deep_agent_defaults_to_state_backend(self, mock_create_agent):
-        """When no backend is provided, defaults to StateBackend."""
+        """When no backend is provided, defaults to StateBackend. With no skills_backend
+        either, no skills middleware is wired and ``_skills_backend`` stays None."""
         bot_config = _make_config()
         mock_messages_storage = MagicMock()
         mock_llm = MagicMock()
@@ -116,9 +124,10 @@ class TestLLMDeepAgent(unittest.IsolatedAsyncioTestCase):
         agent = LLMDeepAgent(mock_llm, bot_config, system_instructions, mock_messages_storage)
 
         self.assertIsNone(agent._backend_wrapper)
-        from deepagents.backends import StateBackend
-
         self.assertIsInstance(agent._backend, StateBackend)
+        # No skills_backend was injected → no implicit default; SkillsMiddleware
+        # will be omitted by initialize_async_resources.
+        self.assertIsNone(agent._skills_backend)
 
     async def test_deep_agent_clean_context_clears_backend_wrapper(self):
         """clean_context should also clear the backend wrapper."""
@@ -141,6 +150,310 @@ class TestLLMDeepAgent(unittest.IsolatedAsyncioTestCase):
         await agent.clean_context()
 
         mock_backend_wrapper.clear.assert_awaited_once()
+
+    def test_resolve_skills_sources_parses_label_syntax(self):
+        """_resolve_skills_sources parses bare paths and ::LABEL= syntax."""
+        self.assertEqual(_resolve_skills_sources(None), [])
+        self.assertEqual(_resolve_skills_sources([]), [])
+        self.assertEqual(_resolve_skills_sources(["/a"]), ["/a"])
+        self.assertEqual(_resolve_skills_sources(["/a", "/b::LABEL=Alpha"]), ["/a", ("/b", "Alpha")])
+        self.assertEqual(_resolve_skills_sources(["/c::LABEL=My Skills"]), [("/c", "My Skills")])
+        self.assertEqual(_resolve_skills_sources([""]), [])
+        self.assertEqual(_resolve_skills_sources(["/a", "", "/b"]), ["/a", "/b"])
+
+    def test_resolve_skills_sources_passes_tuples_through(self):
+        """_resolve_skills_sources passes (path, label) tuples through unchanged."""
+        self.assertEqual(_resolve_skills_sources([("/a", "A"), ("/b", "B")]), [("/a", "A"), ("/b", "B")])
+        # Mixed strings, tuples, and ::LABEL= syntax coexist.
+        self.assertEqual(
+            _resolve_skills_sources(["/a", ("/b", "B"), "/c::LABEL=C"]),
+            ["/a", ("/b", "B"), ("/c", "C")],
+        )
+
+    @patch("manolo_bot.ai.tools.get_all_tools", new_callable=AsyncMock)
+    @patch("manolo_bot.ai.llmagent.create_agent")
+    @patch("manolo_bot.ai.llmdeepagent.create_deep_agent")
+    async def test_deep_agent_passes_skills_when_paths_and_backend_provided(
+        self, mock_create_deep_agent, mock_create_agent, mock_get_all_tools
+    ):
+        """When both skills_paths and skills_backend are provided, a SkillsMiddleware is
+        wired into the middleware list with the explicit backend."""
+        bot_config = _make_config()
+        mock_messages_storage = MagicMock()
+        mock_llm = MagicMock()
+        mock_llm.get_num_tokens = MagicMock(return_value=10)
+        system_instructions = [SystemMessage(content="You are a helpful assistant")]
+        mock_get_all_tools.return_value = []
+        mock_create_deep_agent.return_value = MagicMock()
+
+        skills_wrapper = MagicMock()
+        skills_wrapper.backend = StateBackend()
+
+        agent = LLMDeepAgent(
+            mock_llm,
+            bot_config,
+            system_instructions,
+            mock_messages_storage,
+            skills_paths=["/path/to/skills"],
+            skills_backend=skills_wrapper,
+        )
+        await agent.initialize_async_resources()
+
+        middleware = mock_create_deep_agent.call_args.kwargs["middleware"]
+        skills_mw = next((m for m in middleware if isinstance(m, SkillsMiddleware)), None)
+        self.assertIsNotNone(skills_mw, "SkillsMiddleware not in middleware list")
+        self.assertEqual(skills_mw.sources, ["/path/to/skills"])
+        self.assertIs(skills_mw._backend, skills_wrapper.backend)
+
+    @patch("manolo_bot.ai.tools.get_all_tools", new_callable=AsyncMock)
+    @patch("manolo_bot.ai.llmagent.create_agent")
+    @patch("manolo_bot.ai.llmdeepagent.create_deep_agent")
+    async def test_deep_agent_omits_skills_middleware_when_no_backend(
+        self, mock_create_deep_agent, mock_create_agent, mock_get_all_tools
+    ):
+        """skills_paths without skills_backend produces NO SkillsMiddleware. LLMDeepAgent
+        does not instantiate a skills backend itself — the caller must inject one.
+        A warning is logged so misconfigurations are loud, not silent."""
+        bot_config = _make_config()
+        mock_messages_storage = MagicMock()
+        mock_llm = MagicMock()
+        mock_llm.get_num_tokens = MagicMock(return_value=10)
+        system_instructions = [SystemMessage(content="You are a helpful assistant")]
+        mock_get_all_tools.return_value = []
+        mock_create_deep_agent.return_value = MagicMock()
+
+        with self.assertLogs("manolo_bot.ai.llmdeepagent", level="WARNING") as captured:
+            agent = LLMDeepAgent(
+                mock_llm,
+                bot_config,
+                system_instructions,
+                mock_messages_storage,
+                skills_paths=["/path/to/skills"],
+                # No skills_backend injected.
+            )
+        await agent.initialize_async_resources()
+
+        self.assertEqual(agent._skills_backend, None)
+        middleware = mock_create_deep_agent.call_args.kwargs["middleware"]
+        self.assertEqual(
+            [m for m in middleware if isinstance(m, SkillsMiddleware)],
+            [],
+            "SkillsMiddleware must be omitted when no skills_backend was injected",
+        )
+        # Warning was emitted at construction time.
+        self.assertTrue(any("skills_backend" in m for m in captured.output))
+
+    @patch("manolo_bot.ai.tools.get_all_tools", new_callable=AsyncMock)
+    @patch("manolo_bot.ai.llmagent.create_agent")
+    @patch("manolo_bot.ai.llmdeepagent.create_deep_agent")
+    async def test_deep_agent_skills_use_bot_config_when_ctor_arg_none(
+        self, mock_create_deep_agent, mock_create_agent, mock_get_all_tools
+    ):
+        """When skills_paths is None, skills come from bot_config.deep_agent_skills_paths
+        with ::LABEL= parsing — provided a skills_backend is also injected."""
+        bot_config = _make_config(deep_agent_skills_paths=["/a::LABEL=Alpha", "/b"])
+        mock_messages_storage = MagicMock()
+        mock_llm = MagicMock()
+        mock_llm.get_num_tokens = MagicMock(return_value=10)
+        system_instructions = [SystemMessage(content="You are a helpful assistant")]
+        mock_get_all_tools.return_value = []
+        mock_create_deep_agent.return_value = MagicMock()
+
+        skills_wrapper = MagicMock()
+        skills_wrapper.backend = StateBackend()
+
+        agent = LLMDeepAgent(
+            mock_llm,
+            bot_config,
+            system_instructions,
+            mock_messages_storage,
+            skills_backend=skills_wrapper,
+        )
+        await agent.initialize_async_resources()
+
+        middleware = mock_create_deep_agent.call_args.kwargs["middleware"]
+        skills_mw = next((m for m in middleware if isinstance(m, SkillsMiddleware)), None)
+        self.assertIsNotNone(skills_mw)
+        self.assertIs(skills_mw._backend, skills_wrapper.backend)
+        # deepagents 0.7.5 stores paths on `sources` and labels on `source_labels`.
+        self.assertEqual(skills_mw.sources, ["/a", "/b"])
+        self.assertEqual(skills_mw.source_labels, ["Alpha", "B"])
+
+    @patch("manolo_bot.ai.tools.get_all_tools", new_callable=AsyncMock)
+    @patch("manolo_bot.ai.llmagent.create_agent")
+    @patch("manolo_bot.ai.llmdeepagent.create_deep_agent")
+    async def test_deep_agent_omits_skills_when_neither_set(
+        self, mock_create_deep_agent, mock_create_agent, mock_get_all_tools
+    ):
+        """When neither skills_paths nor deep_agent_skills_paths is set, no skills kwarg is passed."""
+        bot_config = _make_config()
+        mock_messages_storage = MagicMock()
+        mock_llm = MagicMock()
+        mock_llm.get_num_tokens = MagicMock(return_value=10)
+        system_instructions = [SystemMessage(content="You are a helpful assistant")]
+        mock_get_all_tools.return_value = []
+        mock_create_deep_agent.return_value = MagicMock()
+
+        agent = LLMDeepAgent(mock_llm, bot_config, system_instructions, mock_messages_storage)
+        await agent.initialize_async_resources()
+
+        middleware = mock_create_deep_agent.call_args.kwargs["middleware"]
+        skills_mw = [m for m in middleware if isinstance(m, SkillsMiddleware)]
+        self.assertEqual(skills_mw, [], "SkillsMiddleware should not be present")
+
+    @patch("manolo_bot.ai.tools.get_all_tools", new_callable=AsyncMock)
+    @patch("manolo_bot.ai.llmagent.create_agent")
+    @patch("manolo_bot.ai.llmdeepagent.create_deep_agent")
+    async def test_deep_agent_skills_backend_independent_from_main_backend(
+        self, mock_create_deep_agent, mock_create_agent, mock_get_all_tools
+    ):
+        """skills_backend is independent from the agent's main filesystem backend."""
+        main_backend = StateBackend()
+        skills_backend = StateBackend()
+
+        class _MainBackendWrapper(BaseDeepAgentBackend):
+            def _build_backend(self):
+                return main_backend
+
+            async def clear(self):
+                pass
+
+        class _SkillsBackendWrapper(BaseDeepAgentBackend):
+            def _build_backend(self):
+                return skills_backend
+
+            async def clear(self):
+                pass
+
+        bot_config = _make_config()
+        mock_messages_storage = MagicMock()
+        mock_llm = MagicMock()
+        mock_llm.get_num_tokens = MagicMock(return_value=10)
+        system_instructions = [SystemMessage(content="Test")]
+        mock_get_all_tools.return_value = []
+        mock_create_deep_agent.return_value = MagicMock()
+
+        main_wrapper = _MainBackendWrapper(bot_uuid="b", chat_id=1)
+        skills_wrapper = _SkillsBackendWrapper(bot_uuid="b", chat_id=1)
+
+        agent = LLMDeepAgent(
+            mock_llm,
+            bot_config,
+            system_instructions,
+            mock_messages_storage,
+            backend=main_wrapper,
+            skills_paths=["/path/to/skills"],
+            skills_backend=skills_wrapper,
+        )
+        await agent.initialize_async_resources()
+
+        middleware = mock_create_deep_agent.call_args.kwargs["middleware"]
+        fs_mw = next(m for m in middleware if isinstance(m, FilesystemMiddleware))
+        skills_mw = next(m for m in middleware if isinstance(m, SkillsMiddleware))
+
+        # The FilesystemMiddleware is now backed by a CompositeBackend that wraps
+        # the per-chat backend and adds a route per skill source — so the agent's
+        # read_file tool can access skill files at their absolute paths.
+        self.assertIsInstance(fs_mw.backend, CompositeBackend)
+        self.assertIs(fs_mw.backend.default, main_backend)
+        self.assertIs(skills_mw._backend, skills_backend)
+        self.assertIsNot(skills_mw._backend, fs_mw.backend)
+
+    async def test_deep_agent_clean_context_does_not_clear_skills_backend(self):
+        """Skills are operator-provided, not per-chat state — clean_context must not clear them."""
+        bot_config = _make_config(deep_agent_skills_paths=["/etc/manolo_bot/skills"])
+        mock_messages_storage = MagicMock()
+        mock_messages_storage.chat_id = 123
+        mock_messages_storage.clear_messages = AsyncMock()
+        mock_llm = MagicMock()
+        system_instructions = [SystemMessage(content="Test")]
+
+        skills_wrapper = MagicMock()
+        skills_wrapper.backend = StateBackend()
+        skills_wrapper.clear = AsyncMock()
+
+        agent = LLMDeepAgent(
+            mock_llm,
+            bot_config,
+            system_instructions,
+            mock_messages_storage,
+            skills_paths=["/etc/manolo_bot/skills"],
+            skills_backend=skills_wrapper,
+        )
+        agent.documents_storage = None
+
+        await agent.clean_context()
+
+        skills_wrapper.clear.assert_not_awaited()
+
+    @patch("manolo_bot.ai.tools.get_all_tools", new_callable=AsyncMock)
+    @patch("manolo_bot.ai.llmagent.create_agent")
+    @patch("manolo_bot.ai.llmdeepagent.create_deep_agent")
+    async def test_deep_agent_main_backend_has_skill_route_per_source(
+        self, mock_create_deep_agent, mock_create_agent, mock_get_all_tools
+    ):
+        """Each configured skill source becomes a CompositeBackend route whose
+        FilesystemBackend is rooted at that source with virtual_mode=True. This
+        is what lets the agent's read_file tool reach skill files at their
+        absolute paths — the per-chat backend alone would reject them.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_a, tempfile.TemporaryDirectory() as tmp_b:
+            bot_config = _make_config()
+            mock_messages_storage = MagicMock()
+            mock_llm = MagicMock()
+            mock_llm.get_num_tokens = MagicMock(return_value=10)
+            system_instructions = [SystemMessage(content="Test")]
+            mock_get_all_tools.return_value = []
+            mock_create_deep_agent.return_value = MagicMock()
+
+            skills_wrapper = MagicMock()
+            skills_wrapper.backend = StateBackend()
+
+            agent = LLMDeepAgent(
+                mock_llm,
+                bot_config,
+                system_instructions,
+                mock_messages_storage,
+                skills_paths=[tmp_a, (tmp_b, "Project")],
+                skills_backend=skills_wrapper,
+            )
+            await agent.initialize_async_resources()
+
+            middleware = mock_create_deep_agent.call_args.kwargs["middleware"]
+            fs_mw = next(m for m in middleware if isinstance(m, FilesystemMiddleware))
+
+            # A CompositeBackend wraps the default (per-chat) backend.
+            self.assertIsInstance(fs_mw.backend, CompositeBackend)
+            self.assertIsInstance(fs_mw.backend.default, StateBackend)
+            # One route per skill source. Trailing slashes are normalized.
+            self.assertIn(tmp_a.rstrip("/") + "/", fs_mw.backend.routes)
+            self.assertIn(tmp_b.rstrip("/") + "/", fs_mw.backend.routes)
+            # Each route is a FilesystemBackend rooted at the source itself
+            # with virtual_mode=True, so CompositeBackend's prefix-stripping
+            # resolves the stripped path back inside the source directory.
+            for route_prefix, route_backend in fs_mw.backend.routes.items():
+                self.assertIsInstance(route_backend, FilesystemBackend)
+                self.assertTrue(route_backend.virtual_mode)
+                self.assertEqual(
+                    str(route_backend.cwd.resolve()),
+                    route_prefix.rstrip("/"),
+                )
+
+            # End-to-end: the route's FilesystemBackend can ls the source path
+            # and read a SKILL.md living inside it (simulating what the agent's
+            # read_file tool does after this fix).
+            skill_root = tmp_a
+            skill_dir = pathlib.Path(skill_root) / "my-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text("---\nname: my-skill\ndescription: demo\n---\nbody", encoding="utf-8")
+            ls_result = fs_mw.backend.ls(skill_root + "/")
+            self.assertIsNone(ls_result.error)
+            self.assertTrue(any(e["path"].endswith("my-skill/") for e in (ls_result.entries or [])))
+            read_result = fs_mw.backend.read(skill_root + "/my-skill/SKILL.md")
+            self.assertIsNone(getattr(read_result, "error", None))
+            self.assertIn("demo", read_result.file_data["content"])
 
 
 if __name__ == "__main__":

--- a/tests/storage_tests/deep_agent_backends/test_backends.py
+++ b/tests/storage_tests/deep_agent_backends/test_backends.py
@@ -109,12 +109,14 @@ class TestFilesystemDeepAgentBackend(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(backend._virtual_mode)
 
     async def test_clear_refuses_path_outside_workspace(self):
-        """Regression: clear() must not rmtree anything outside workspace_path.
+        """Regression: bot_uuid carrying path-traversal characters is rejected
+        at construction (Layer 1 of the security model), so ``clear()`` never
+        has the chance to operate on a path outside the workspace.
 
-        Simulates bot_uuid carrying a traversal sequence that escapes the
-        configured workspace. The old code blindly joined and rmtree'd; the
-        new code resolves the path and refuses anything not inside the
-        workspace root.
+        The original regression test assumed Layer 2 (containment check at
+        ``clear()`` time) was the primary defense. After adding Layer 1, the
+        unsafe ``bot_uuid`` never makes it past ``__init__``, but Layer 2
+        still exists as defense in depth (see ``test_clear_layer2_refuses_runtime_workspace_mutation``).
         """
         # Plant a victim directory OUTSIDE the workspace.
         outside_base = tempfile.mkdtemp(prefix="manolo_bot_test_outside_")
@@ -125,22 +127,94 @@ class TestFilesystemDeepAgentBackend(unittest.IsolatedAsyncioTestCase):
             f.write("do-not-delete")
 
         try:
-            # Workspace lives somewhere else; bot_uuid contains a traversal
-            # sequence that would, under the old code, have resolved into
-            # outside_base.
             workspace = tempfile.mkdtemp(prefix="manolo_bot_test_ws_")
             traversal_uuid = os.pardir + os.sep + os.path.basename(outside_base) + os.sep + "victim_dir"
-            try:
-                backend = FilesystemDeepAgentBackend(traversal_uuid, 0, workspace)
-                await backend.clear()
-                self.assertTrue(
-                    os.path.exists(victim_file),
-                    "clear() must not delete files outside the workspace",
-                )
-            finally:
-                shutil.rmtree(workspace)
+            with self.assertRaises(ValueError) as cm:
+                FilesystemDeepAgentBackend(traversal_uuid, 0, workspace)
+            self.assertIn("bot_uuid", str(cm.exception))
+            # Victim file is preserved because construction failed.
+            self.assertTrue(os.path.exists(victim_file))
         finally:
+            shutil.rmtree(workspace)
             shutil.rmtree(outside_base)
+
+    def test_bot_uuid_with_path_traversal_raises_at_construction(self):
+        """Layer 1: bot_uuid containing '..' is rejected at construction."""
+        with self.assertRaises(ValueError) as cm:
+            FilesystemDeepAgentBackend("../etc", 12345, self.workspace)
+        self.assertIn("bot_uuid", str(cm.exception))
+
+    def test_bot_uuid_with_slash_raises_at_construction(self):
+        """Layer 1: bot_uuid containing '/' is rejected."""
+        with self.assertRaises(ValueError):
+            FilesystemDeepAgentBackend("foo/bar", 12345, self.workspace)
+
+    def test_bot_uuid_with_dot_only_raises_at_construction(self):
+        """Layer 1: bot_uuid equal to '.' is rejected."""
+        with self.assertRaises(ValueError):
+            FilesystemDeepAgentBackend(".", 12345, self.workspace)
+
+    def test_empty_bot_uuid_raises_at_construction(self):
+        """Layer 1: empty bot_uuid is rejected."""
+        with self.assertRaises(ValueError):
+            FilesystemDeepAgentBackend("", 12345, self.workspace)
+
+    def test_bot_uuid_with_non_string_raises_at_construction(self):
+        """Layer 1: non-string bot_uuid is rejected."""
+        with self.assertRaises(ValueError):
+            FilesystemDeepAgentBackend(None, 12345, self.workspace)  # type: ignore[arg-type]
+
+    def test_relative_workspace_path_raises_at_construction(self):
+        """Layer 1: relative workspace_path is rejected."""
+        with self.assertRaises(ValueError) as cm:
+            FilesystemDeepAgentBackend("ok-bot", 12345, "relative/path")
+        self.assertIn("workspace_path", str(cm.exception))
+
+    def test_empty_workspace_path_raises_at_construction(self):
+        """Layer 1: empty workspace_path is rejected."""
+        with self.assertRaises(ValueError):
+            FilesystemDeepAgentBackend("ok-bot", 12345, "")
+
+    def test_valid_config_passes_validation(self):
+        """Layer 1: realistic bot_uuid (with dashes and underscores) and absolute
+        workspace_path construct successfully."""
+        backend = FilesystemDeepAgentBackend("valid-bot_123", 456, self.workspace)
+        self.assertEqual(backend.bot_uuid, "valid-bot_123")
+        self.assertEqual(backend.chat_id, 456)
+
+    async def test_layer2_refuses_symlink_escape_at_construction(self):
+        """Layer 2 (defense in depth): if the workspace contains a symlink
+        pointing outside, a valid ``bot_uuid`` whose name matches that
+        symlink makes the resolved ``chat_path`` escape the workspace root.
+        ``os.path.realpath`` follows the symlink during construction (via
+        ``_build_backend``); the containment check rejects the backend
+        before any agent can run.
+        """
+        workspace = tempfile.mkdtemp(prefix="manolo_bot_test_ws_")
+        outside = tempfile.mkdtemp(prefix="manolo_bot_test_outside_")
+        # Plant a symlink inside the workspace that points outside.
+        os.symlink(outside, os.path.join(workspace, "escape_link"))
+        try:
+            # Layer 1 passes (bot_uuid matches the regex), Layer 2 must catch
+            # the symlink escape at construction.
+            with self.assertRaises(ValueError) as cm:
+                FilesystemDeepAgentBackend("escape_link", 12345, workspace)
+            self.assertIn("outside workspace_path", str(cm.exception))
+        finally:
+            shutil.rmtree(workspace)
+            shutil.rmtree(outside)
+
+    def test_layer2_passes_for_normal_chat_path(self):
+        """Smoke test: Layer 2 must NOT raise for an ordinary chat path
+        (no symlink escape, no traversal)."""
+        workspace = tempfile.mkdtemp(prefix="manolo_bot_test_ws_")
+        try:
+            backend = FilesystemDeepAgentBackend("ok-bot", 12345, workspace)
+            chat_path = backend._safe_chat_path()
+            self.assertIn("ok-bot", chat_path)
+            self.assertIn("12345", chat_path)
+        finally:
+            shutil.rmtree(workspace)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #70.

## Skills feature

Implements `deepagents` `SkillsMiddleware` support for `LLMDeepAgent`:

- New `skills_paths` (`Sequence[str | tuple[str, str]] | None`) and `skills_backend` (`BaseSkillsBackend | None`) ctor params on `LLMDeepAgent`. The wrapper is **explicitly injected** by the caller — `LLMDeepAgent` does not instantiate a default. If `skills_backend=None`, `SkillsMiddleware` is omitted entirely and a `WARNING` is logged when `skills_paths` is also set.
- New `BaseSkillsBackend` ABC in `manolo_bot/storage/deep_agent_backends/base.py`, parallel to `BaseDeepAgentBackend`. Contract: `.backend` property (returns a `BackendProtocol`) + async `.clear()`. Library users subclass for custom storage (Redis, S3, in-memory, etc.).
- New `SkillsFilesystemDeepAgentBackend(BaseSkillsBackend)` in `manolo_bot/storage/deep_agent_backends/skills_filesystem_backend.py`. Uses `virtual_mode=False` so absolute skill paths (`/etc/manolo_bot/skills`, etc.) resolve directly on the host. Read-only via `SkillsMiddleware`, so unrestricted access is safe.
- `LLMDeepAgent` wraps the agent's main filesystem backend with a `CompositeBackend` that adds one route per skill source. Each route is a sandboxed `FilesystemBackend(root_dir=<source>, virtual_mode=True)` — letting the agent's runtime `read_file` / `ls` / `glob` / `grep` tools reach skill files at their absolute paths (which the per-chat backend alone would reject).
- `DEEP_AGENT_SKILLS_PATHS` env var with `<path>::LABEL=<text>` syntax for source labels.
- `main.py` constructs the shared wrapper at module load and passes it explicitly to every `LLMDeepAgent`.
- Docs: `env.example`, `README.md`, `usage_app.rst`, `usage_library.rst` (rewrote Skills section + new "Skill-file routing" subsection), `api.rst` (added `manolo_bot.ai.llmdeepagent` and `manolo_bot.storage.deep_agent_backends.skills_filesystem_backend` automodules).

## Path-traversal hardening

`FilesystemDeepAgentBackend.clear()` previously joined `bot_uuid` and `chat_id` into `workspace_path` and ran `shutil.rmtree` without verifying the result was still under the workspace. A typo or attacker-controlled env var (`BOT_UUID=../etc`) would let `/flushcontext` delete directories outside the configured workspace — the concern flagged as out-of-scope in the original issue.

Two-layer defense:

- **Layer 1** (construction): `bot_uuid` must match `[A-Za-z0-9_-]+`; `workspace_path` must be absolute. `ValueError` raised on bad input.
- **Layer 2** (use time): `realpath` + `commonpath` containment check verifies the resolved chat_path is still under `workspace_path` before `shutil.rmtree` runs.

## Tests

- **154 → 164 tests green** (`uv run python -m unittest discover tests`).
- 10 new tests in `tests/storage_tests/deep_agent_backends/test_backends.py` covering both security layers.
- Sphinx build clean (`uv run sphinx-build -b html -W docs/source docs/_build/html`).

## Files changed

```
M README.md
M docs/source/api.rst
M docs/source/usage_app.rst
M docs/source/usage_library.rst
M env.example
M manolo_bot/ai/config.py
M manolo_bot/ai/llmdeepagent.py
M manolo_bot/config.py
M manolo_bot/main.py
M manolo_bot/storage/deep_agent_backends/base.py
M manolo_bot/storage/deep_agent_backends/filesystem_backend.py
A manolo_bot/storage/deep_agent_backends/skills_filesystem_backend.py
M tests/ai_tests/test_llmdeepagent.py
M tests/storage_tests/deep_agent_backends/test_backends.py
```